### PR TITLE
Look for the module assuming path is an absolute path.

### DIFF
--- a/src/fixture_loader.coffee
+++ b/src/fixture_loader.coffee
@@ -9,6 +9,7 @@ class exports.FixtureLoader
   require: (module) ->
     currdir = process.cwd()
     for path in @path
+      try return require path + '/' + module catch e
       try return require currdir + '/' + path + '/' + module catch e
     throw 'Cannot find ' + module
 


### PR DESCRIPTION
If you are trying to load modules using an absolute path it does not work because of:
   currdir + '/' + path

I have made the easiest of changes, where it just lookd for the module twice. First using absolute- and then using relative-path.
