### PR TITLE
Fix deserialization of empty element

### DIFF
--- a/src/serializer.coffee
+++ b/src/serializer.coffee
@@ -21,7 +21,7 @@ class Deserializer
   token: (length) ->
     result = @command[0..length - 1]
     @command = @command[length + 1..]
-    result
+    length and result or ''
 
   is_deserializable: ->
     @command?.length > 1 and

--- a/test/deserialize_command.coffee
+++ b/test/deserialize_command.coffee
@@ -23,6 +23,10 @@ describe 'command deserializer', ->
 
      verify '[000001:000005:hello:]', ['hello']
 
+  it 'should deserialize empty element', ->
+
+     verify '[000001:000000::]', ['']
+
   it 'should deserialize multiple elements', ->
 
     verify '[000002:000004:good:000003:bye:]', ['good', 'bye']


### PR DESCRIPTION
An empty element (e.g. a blank table cell) was incorrectly deserialized as a single colon (':') -- this patch fixes the problem
